### PR TITLE
Fix file visibility update bug and handle shared emails safely

### DIFF
--- a/app/templates/update_file.html
+++ b/app/templates/update_file.html
@@ -13,7 +13,7 @@
     {{ form.visibility.label }} {{ form.visibility(class="form-control") }}
   </div>
 
-  {% if file.visibility != 'public' %}
+  {% if file.visibility %}
   <div class="form-group">
     {{ form.share_with.label }}
     <div class="input-group">


### PR DESCRIPTION
This PR prevents the crash and correctly updates shared users.
- Fixes the server error (500) when switching a file's visibility from `public` to `shared`.
- Safely handles `form.share_with.data` whether it is a string or a list.
- Preserves existing shared emails and merges newly added emails correctly.

## Related Issue
Closes [#19](https://github.com/flappyfishhh/cits5505-masters62/issues/19)

