### PR TITLE
Unify styling for Register, Forgot Password, and Reset Password pages

### DIFF
--- a/app/templates/forgot_password.html
+++ b/app/templates/forgot_password.html
@@ -1,15 +1,25 @@
-{% extends 'base.html' %} {% block title %}Forgot Password{% endblock %} {%
-block content %}
-<h1>Forgot Password</h1>
-<form method="post" action="{{ url_for('main.forgot_password') }}">
-  {{ form.hidden_tag() }}
-  <div class="form-group">
-    {{ form.email.label }} {{ form.email(class="form-control",
-    placeholder="Enter your registered email") }} {% for err in
-    form.email.errors %}
-    <div class="errors">{{ err }}</div>
-    {% endfor %}
+{% extends 'base.html' %} 
+{% block title %}Forgot Password{% endblock %} 
+{%block content %}
+<div class="min-h-screen flex items-center justify-center bg-transparent">
+  <div class="max-w-md mx-auto bg-white/5 p-6 rounded-2xl shadow-lg backdrop-blur-md border border-white/10 w-full">
+    <h1 class="text-3xl font-bold text-center text-[var(--primary-color)] mb-6">Forgot Password</h1>
+    <form method="post" action="{{ url_for('main.forgot_password') }}" class="space-y-4">
+      {{ form.hidden_tag() }}
+
+      <div>
+        {{ form.email.label(class="block mb-1 font-medium") }} 
+        {{ form.email(class="w-full py-2 rounded-md bg-white/10 placeholder-gray-400 border border-white/20 focus:outline-none px-4",
+        placeholder="Enter your registered email") }} 
+        {% for err in form.email.errors %}
+          <div class="text-red-500 text-sm mt-1">{{ err }}</div>
+        {% endfor %}
+      </div>
+
+      <div>
+        {{ form.submit(class="custom-btn w-full py-2 rounded-md text-center") }}
+      </div>
+    </form>
   </div>
-  <div class="form-group">{{ form.submit(class="btn") }}</div>
-</form>
+</div>
 {% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,59 +1,59 @@
 {% extends 'base.html' %} 
 {% block title %}Register{% endblock %} 
 {% block content %}
-<main class="flex justify-center px-4 py-12 sm:py-16 lg:py-20">
-  <div class="backdrop-blur-md bg-white/5 p-6 sm:p-8 rounded-2xl shadow-2xl max-w-2xl w-full border border-white/10 text-white">
-    <h1 class="text-3xl sm:text-4xl font-extrabold mb-6 text-[var(--primary-color)] text-center">Create an Account</h1>
+<div class="min-h-screen flex items-center justify-center bg-transparent">
+  <div class="max-w-md mx-auto bg-white/5 p-6 rounded-2xl shadow-lg backdrop-blur-md border border-white/10 w-full">
+    <h1 class="text-3xl font-bold text-center text-[var(--primary-color)] mb-6">Create an Account</h1>
     <form method="post" action="{{ url_for('main.register') }}" class="space-y-4">
       {{ form.hidden_tag() }}
 
       <div>
-        {{ form.username.label(class="block mb-1") }} 
-        {{ form.username(class="w-full px-4 py-2 rounded bg-white/10 border border-white/20 focus:outline-none",placeholder="Username") }} 
+        {{ form.username.label(class="block mb-1 font-medium") }} 
+        {{ form.username(class="rounded-md bg-white/10 placeholder-gray-400 border border-white/20 focus:outline-none px-4",placeholder="Username") }} 
         {% for err in form.username.errors %}
-          <div class="text-red-400 text-sm">{{ err }}</div>
+          <div class="text-red-400 text-sm mt-1">{{ err }}</div>
         {% endfor %}
       </div>
 
       <div>
-        {{ form.email.label(class="block mb-1") }} 
-        {{ form.email(class="w-full px-4 py-2 rounded bg-white/10 border border-white/20 focus:outline-none",placeholder="Email") }} 
+        {{ form.email.label(class="block mb-1 font-medium") }} 
+        {{ form.email(class="w-full py-2 rounded-md bg-white/10 placeholder-gray-400 border border-white/20 focus:outline-none px-4",placeholder="Email") }} 
         {% for err in form.email.errors %}
           <div class="text-red-400 text-sm">{{ err }}</div>
         {% endfor %}
       </div>
 
       <div>
-        {{ form.password.label(class="block mb-1") }} 
-        {{ form.password(class="w-full px-4 py-2 rounded bg-white/10 border border-white/20 focus:outline-none",placeholder="Password") }} 
+        {{ form.password.label(class="block mb-1 font-medium") }} 
+        {{ form.password(class="w-full py-2 rounded-md bg-white/10 placeholder-gray-400 border border-white/20 focus:outline-none px-4",placeholder="Password") }} 
         {% for err in form.password.errors %}
           <div class="text-red-400 text-sm">{{ err }}</div>
         {% endfor %}
       </div>
 
       <div>
-        {{ form.password2.label(class="block mb-1") }} 
-        {{ form.password2(class="w-full px-4 py-2 rounded bg-white/10 border border-white/20 focus:outline-none",placeholder="Repeat Password") }} 
+        {{ form.password2.label(class="block mb-1 font-medium") }} 
+        {{ form.password2(class="w-full py-2 rounded-md bg-white/10 placeholder-gray-400 border border-white/20 focus:outline-none px-4",placeholder="Repeat Password") }} 
         {% for err in form.password2.errors %}
           <div class="text-red-400 text-sm">{{ err }}</div>
         {% endfor %}
       </div>
 
       <div>
-        {{ form.security_answer.label(class="block mb-1") }} {{
-        form.security_answer(class="w-full px-4 py-2 rounded bg-white/10 border border-white/20 focus:outline-none", placeholder="What was the name of your first pet?") }} 
+        {{ form.security_answer.label(class="block mb-1 font-medium") }} {{
+        form.security_answer(class="w-full py-2 rounded-md bg-white/10 placeholder-gray-400 border border-white/20 focus:outline-none px-4", placeholder="What was the name of your first pet?") }} 
         {% for err in form.security_answer.errors %}
           <div class="text-red-400 text-sm">{{ err }}</div>
         {% endfor %}
       </div>
 
-      <div>{{ form.submit(class="custom-btn px-6 py-2 rounded-xl shadow-md") }}</div>
+      <div>{{ form.submit(class="custom-btn w-full py-2 rounded-md text-center") }}</div>
     </form>
 
-    <p class="mt-4 text-sm text-[var(--muted-color)] text-center">
+    <div class="mt-4 text-sm text-gray-400 text-center">
       Already have an account?
-      <a href="{{ url_for('main.login') }}" class="underline hover:text-white">Sign in here</a>.
-    </p>
+      <a href="{{ url_for('main.login') }}" class="hover:underline">Sign in here</a>.
+    </div>
   </div>
-</main> 
+</div> 
 {% endblock %}

--- a/app/templates/reset_password.html
+++ b/app/templates/reset_password.html
@@ -1,32 +1,42 @@
-{% extends 'base.html' %} {% block title %}Reset Password{% endblock %} {% block
-content %}
-<h1>Reset Password</h1>
-<form
-  method="post"
-  action="{{ url_for('main.reset_password', user_id=request.view_args.user_id) }}"
->
-  {{ form.hidden_tag() }}
-  <div class="form-group">
-    {{ form.security_answer.label }} {{
-    form.security_answer(class="form-control", placeholder="Answer your pet
-    name") }} {% for err in form.security_answer.errors %}
-    <div class="errors">{{ err }}</div>
-    {% endfor %}
+{% extends 'base.html' %} 
+{% block title %}Reset Password{% endblock %} 
+{% block content %}
+<div class="min-h-screen flex items-center justify-center bg-transparent">
+  <div class="max-w-md mx-auto bg-white/5 p-6 rounded-2xl shadow-lg backdrop-blur-md border border-white/10 w-full">
+    <h1 class="text-3xl font-bold text-center text-[var(--primary-color)] mb-6">Reset Password</h1>
+    <form method="post" action="{{ url_for('main.reset_password', user_id=request.view_args.user_id) }}" class="space-y-4">
+      {{ form.hidden_tag() }}
+
+      <div>
+        {{ form.security_answer.label(class="block mb-1 font-medium") }} 
+        {{ form.security_answer(class="w-full py-2 rounded-md bg-white/10 placeholder-gray-400 border border-white/20 focus:outline-none px-4", placeholder="Answer your petname") }} 
+        {% for err in form.security_answer.errors %}
+          <div class="errors">{{ err }}</div>
+        {% endfor %}
+      </div>
+
+      <div>
+        {{ form.new_password.label(class="block mb-1 font-medium") }} 
+        {{ form.new_password(class="w-full py-2 rounded-md bg-white/10 placeholder-gray-400 border border-white/20 focus:outline-none px-4",
+        placeholder="Enter new password") }} 
+        {% for err in form.new_password.errors%}
+          <div class="text-red-500 text-sm mt-1">{{ err }}</div>
+        {% endfor %}
+      </div>
+
+      <div>
+        {{ form.new_password2.label(class="block mb-1 font-medium") }} 
+        {{ form.new_password2(class="w-full py-2 rounded-md bg-white/10 placeholder-gray-400 border border-white/20 focus:outline-none px-4",
+        placeholder="Repeat new password") }} 
+        {% for err in form.new_password2.errors %}
+          <div class="text-red-500 text-sm mt-1">{{ err }}</div>
+        {% endfor %}
+      </div>
+
+      <div>
+        {{ form.submit(class="custom-btn w-full py-2 rounded-md text-center") }}
+      </div>
+    </form>
   </div>
-  <div class="form-group">
-    {{ form.new_password.label }} {{ form.new_password(class="form-control",
-    placeholder="Enter new password") }} {% for err in form.new_password.errors
-    %}
-    <div class="errors">{{ err }}</div>
-    {% endfor %}
-  </div>
-  <div class="form-group">
-    {{ form.new_password2.label }} {{ form.new_password2(class="form-control",
-    placeholder="Repeat new password") }} {% for err in
-    form.new_password2.errors %}
-    <div class="errors">{{ err }}</div>
-    {% endfor %}
-  </div>
-  <div class="form-group">{{ form.submit(class="btn") }}</div>
-</form>
+</div>
 {% endblock %}


### PR DESCRIPTION
This PR updates the styling of three key authentication pages to match the modern design used on the login page:

- **Register Page**: Adjusted layout, spacing, and component styles to match login view.
- **Forgot Password**: Added background blur, consistent label/input styling, and visual hierarchy.
- **Reset Password**: Reformatted the form layout and applied Tailwind utilities for a cleaner user experience.

The result is a unified and polished interface across all authentication flows, improving both aesthetics and usability.
