### PR TITLE
add script to reset app.db and migrations for development use

### DIFF
--- a/tests/reset_dev_db.sh
+++ b/tests/reset_dev_db.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo "Resetting development database..."
+
+# Set environment
+export FLASK_APP=solaranalytics.py
+export FLASK_ENV=development
+
+# Step 1: Delete existing SQLite DB
+if [ -f "app.db" ]; then
+    echo "Removing existing app.db"
+    rm app.db
+fi
+
+# Step 2: Delete existing migrations folder
+if [ -d "migrations" ]; then
+    echo "Removing existing migrations folder"
+    rm -rf migrations
+fi
+
+# Step 3: Re-initialize migrations
+echo "Initializing migrations..."
+flask db init
+
+# Step 4: Generate new migration scripts
+echo "Generating migration scripts..."
+flask db migrate -m "Reset DB"
+
+# Step 5: Apply migrations to create fresh DB schema
+echo "Applying migrations..."
+flask db upgrade
+
+echo "Development database reset complete."


### PR DESCRIPTION
### Problem
- The Selenium test suite uses a temporary in-memory database (`sqlite:///:memory:`) configured via the test fixture in `conftest.py`.
- The development database (`app.db`) may be left uninitialized or outdated after testing, leading to errors like `no such table: users`.

### Solution
This pull request adds a helper script (`reset_dev_db.sh`) that:
- Removes the existing `app.db` and `migrations/` folder
- Re-initializes migrations
- Applies all migrations using `flask db upgrade`

### Usage
Run the script from the project root using:

```bash
./tests/reset_dev_db.sh
